### PR TITLE
feat: Implement backend REST APIs with JWT authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,28 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.5</version> <!-- Use a recent version -->
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/cofeecode/application/powerhauscore/controllers/api/AuthController.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/controllers/api/AuthController.java
@@ -1,0 +1,50 @@
+package com.cofeecode.application.powerhauscore.controllers.api;
+
+import com.cofeecode.application.powerhauscore.data.User;
+import com.cofeecode.application.powerhauscore.dto.JwtResponseDTO;
+import com.cofeecode.application.powerhauscore.dto.LoginRequestDTO;
+import com.cofeecode.application.powerhauscore.repository.UserRepository;
+import com.cofeecode.application.powerhauscore.security.JwtTokenProvider;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthController(AuthenticationManager authenticationManager,
+                          UserRepository userRepository,
+                          JwtTokenProvider jwtTokenProvider) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequestDTO loginRequest) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        String jwt = jwtTokenProvider.generateTokenFromUsername(userDetails.getUsername(), userDetails.getAuthorities());
+
+        User user = userRepository.findByUsername(userDetails.getUsername()).orElseThrow(
+                () -> new RuntimeException("User " + userDetails.getUsername() + " not found after authentication")
+        );
+
+        return ResponseEntity.ok(new JwtResponseDTO(jwt, user.getId(), user.getUsername(), user.getName(), user.getRoles()));
+    }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/controllers/api/ProjectController.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/controllers/api/ProjectController.java
@@ -1,0 +1,70 @@
+package com.cofeecode.application.powerhauscore.controllers.api;
+
+import com.cofeecode.application.powerhauscore.data.Project;
+import com.cofeecode.application.powerhauscore.dto.ProjectRequestDTO;
+import com.cofeecode.application.powerhauscore.services.ProjectService;
+import jakarta.annotation.security.RolesAllowed; // Ensure this import is present
+import jakarta.validation.Valid;
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @GetMapping
+    @RolesAllowed({"USER", "RVC", "HR", "ADMIN"})
+    public ResponseEntity<Page<Project>> getAllProjects(Pageable pageable) {
+        Page<Project> projects = projectService.list(pageable);
+        return ResponseEntity.ok(projects);
+    }
+
+    @GetMapping("/{id}")
+    @RolesAllowed({"USER", "RVC", "HR", "ADMIN"})
+    public ResponseEntity<Project> getProjectById(@PathVariable Long id) {
+        return projectService.get(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @RolesAllowed({"USER", "RVC", "HR", "ADMIN"})
+    public ResponseEntity<Project> createProject(@Valid @RequestBody ProjectRequestDTO projectDTO) {
+        Project project = new Project();
+        BeanUtils.copyProperties(projectDTO, project);
+        Project createdProject = projectService.create(project);
+        return new ResponseEntity<>(createdProject, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @RolesAllowed({"USER", "RVC", "HR", "ADMIN"})
+    public ResponseEntity<Project> updateProject(@PathVariable Long id, @Valid @RequestBody ProjectRequestDTO projectDTO) {
+        Project existingProject = projectService.get(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found with id: " + id));
+
+        BeanUtils.copyProperties(projectDTO, existingProject, "id");
+        Project updatedProject = projectService.update(existingProject);
+        return ResponseEntity.ok(updatedProject);
+    }
+
+    @DeleteMapping("/{id}")
+    @RolesAllowed({"ADMIN"})
+    public ResponseEntity<Void> deleteProject(@PathVariable Long id) {
+        if (!projectService.get(id).isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+        projectService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/dto/JwtResponseDTO.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/dto/JwtResponseDTO.java
@@ -1,0 +1,36 @@
+package com.cofeecode.application.powerhauscore.dto;
+
+// Assuming Role enum/class is in this package, adjust if necessary
+import com.cofeecode.application.powerhauscore.data.Role;
+import java.util.Set;
+
+public class JwtResponseDTO {
+    private String token;
+    private String type = "Bearer";
+    private Long id;
+    private String username;
+    private String name;
+    private Set<Role> roles;
+
+    public JwtResponseDTO(String token, Long id, String username, String name, Set<Role> roles) {
+        this.token = token;
+        this.id = id;
+        this.username = username;
+        this.name = name;
+        this.roles = roles;
+    }
+
+    // Getters and Setters
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public Set<Role> getRoles() { return roles; }
+    public void setRoles(Set<Role> roles) { this.roles = roles; }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/dto/LoginRequestDTO.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/dto/LoginRequestDTO.java
@@ -1,0 +1,16 @@
+package com.cofeecode.application.powerhauscore.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequestDTO {
+    @NotBlank
+    private String username;
+    @NotBlank
+    private String password;
+
+    // Getters and Setters
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/dto/ProjectRequestDTO.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/dto/ProjectRequestDTO.java
@@ -1,0 +1,71 @@
+package com.cofeecode.application.powerhauscore.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class ProjectRequestDTO {
+
+    @NotBlank(message = "Project name cannot be blank")
+    private String name;
+
+    private String description;
+
+    @NotNull(message = "Start date is required")
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private BigDecimal budget;
+
+    @NotBlank(message = "Status cannot be blank")
+    private String status;
+
+    @NotBlank(message = "Client cannot be blank")
+    private String client;
+
+    private String manager;
+
+    private String location;
+
+    private boolean isPriority;
+
+    public ProjectRequestDTO() {
+    }
+
+    public ProjectRequestDTO(String name, String description, LocalDate startDate, LocalDate endDate, BigDecimal budget, String status, String client, String manager, String location, boolean isPriority) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.budget = budget;
+        this.status = status;
+        this.client = client;
+        this.manager = manager;
+        this.location = location;
+        this.isPriority = isPriority;
+    }
+
+    // Getters and Setters
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public LocalDate getStartDate() { return startDate; }
+    public void setStartDate(LocalDate startDate) { this.startDate = startDate; }
+    public LocalDate getEndDate() { return endDate; }
+    public void setEndDate(LocalDate endDate) { this.endDate = endDate; }
+    public BigDecimal getBudget() { return budget; }
+    public void setBudget(BigDecimal budget) { this.budget = budget; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getClient() { return client; }
+    public void setClient(String client) { this.client = client; }
+    public String getManager() { return manager; }
+    public void setManager(String manager) { this.manager = manager; }
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+    public boolean isPriority() { return isPriority; }
+    public void setPriority(boolean priority) { isPriority = priority; }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/security/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.cofeecode.application.powerhauscore.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService; // Spring's UserDetailsService
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+// Make this a component so it can be picked up by Spring configuration
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtTokenProvider tokenProvider;
+
+    @Autowired
+    private UserDetailsService userDetailsServiceImpl; // Autowire your UserDetailsServiceImpl
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                String username = tokenProvider.getUsernameFromJWT(jwt);
+
+                UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception ex) {
+            // Use logger from OncePerRequestFilter or define your own
+            logger.error("Could not set user authentication in security context", ex);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/security/JwtTokenProvider.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/security/JwtTokenProvider.java
@@ -1,0 +1,102 @@
+package com.cofeecode.application.powerhauscore.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
+
+    @Value("${app.jwt.secret:DefaultSecretKeyNeedsToBeLongEnoughForHS256Algorithm}") // Define this in application.properties
+    private String jwtSecretString;
+
+    @Value("${app.jwt.expiration-ms:86400000}") // Define this in application.properties (default 1 day)
+    private int jwtExpirationMs;
+
+    private SecretKey jwtSecretKey;
+
+    @jakarta.annotation.PostConstruct
+    public void init() {
+        byte[] secretBytes = jwtSecretString.getBytes();
+        if (secretBytes.length < 32) { // HS256 needs at least 256 bits (32 bytes)
+            logger.warn("JWT secret is too short (less than 32 bytes). Using a default generated key. PLEASE CONFIGURE a strong 'app.jwt.secret' in application.properties");
+            this.jwtSecretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256); // Generates a new secure key
+        } else {
+            this.jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
+        }
+    }
+
+    public String generateToken(Authentication authentication) {
+        UserDetails userPrincipal = (UserDetails) authentication.getPrincipal();
+        // Consider fetching roles if they are not already part of UserDetails authorities as simple strings
+        String roles = userPrincipal.getAuthorities().stream()
+                           .map(GrantedAuthority::getAuthority)
+                           .collect(Collectors.joining(","));
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtExpirationMs);
+
+        return Jwts.builder()
+                .setSubject(userPrincipal.getUsername())
+                .claim("roles", roles) // Adding roles as a claim
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(jwtSecretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateTokenFromUsername(String username, java.util.Collection<? extends GrantedAuthority> authorities) {
+        String roles = authorities.stream()
+                           .map(GrantedAuthority::getAuthority)
+                           .collect(Collectors.joining(","));
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtExpirationMs);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("roles", roles)
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(jwtSecretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUsernameFromJWT(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(jwtSecretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String authToken) {
+        try {
+            Jwts.parserBuilder().setSigningKey(jwtSecretKey).build().parseClaimsJws(authToken);
+            return true;
+        } catch (MalformedJwtException ex) {
+            logger.error("Invalid JWT token: {}", ex.getMessage());
+        } catch (ExpiredJwtException ex) {
+            logger.error("Expired JWT token: {}", ex.getMessage());
+        } catch (UnsupportedJwtException ex) {
+            logger.error("Unsupported JWT token: {}", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            logger.error("JWT claims string is empty: {}", ex.getMessage());
+        } catch (io.jsonwebtoken.security.SignatureException ex) {
+            logger.error("JWT signature does not match locally computed signature: {}", ex.getMessage());
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/security/SecurityConfiguration.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/security/SecurityConfiguration.java
@@ -1,38 +1,78 @@
 package com.cofeecode.application.powerhauscore.security;
 
-import com.cofeecode.application.powerhauscore.views.login.LoginView;
-import com.vaadin.flow.spring.security.VaadinWebSecurity;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
-@EnableWebSecurity
 @Configuration
-public class SecurityConfiguration extends VaadinWebSecurity {
+@EnableWebSecurity
+@EnableMethodSecurity(jsr250Enabled = true, securedEnabled = true) // To enable @RolesAllowed, @Secured
+public class SecurityConfiguration {
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    // UserDetailsServiceImpl is expected to be a @Service and autowired by Spring elsewhere if needed,
+    // or directly used by the AuthenticationManagerBuilder if configuring that way.
+    // For this setup, it's primarily used by JwtAuthenticationFilter which is a @Component.
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-
-        http
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(new AntPathRequestMatcher("/uploads/**")).permitAll()  // Allow public access to file operations
-                        .requestMatchers(new AntPathRequestMatcher("/images/*.png")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/line-awesome/**/*.svg")).permitAll()
-                )
-                .csrf(csrf -> csrf.ignoringRequestMatchers("/uploads/**"))  // Ignore CSRF for file deletions
-                .formLogin(form -> form.defaultSuccessUrl("/transactions", true));
-
-        super.configure(http);
-        setLoginView(http, LoginView.class);
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    new AntPathRequestMatcher("/api/v1/auth/**"),
+                    new AntPathRequestMatcher("/uploads/**"),
+                    new AntPathRequestMatcher("/images/*.png"),
+                    new AntPathRequestMatcher("/line-awesome/**/*.svg"),
+                    // OpenAPI & Swagger UI paths
+                    new AntPathRequestMatcher("/api/v1/api-docs"), // Path for the api-docs
+                    new AntPathRequestMatcher("/api/v1/api-docs/**"), // Path for the api-docs and its subpaths
+                    new AntPathRequestMatcher("/swagger-ui.html"),
+                    new AntPathRequestMatcher("/swagger-ui/**"),
+                    // Vaadin public resources (if keeping Vaadin UI accessible)
+                    AntPathRequestMatcher.antMatcher("/VAADIN/**"),
+                    AntPathRequestMatcher.antMatcher("/login"), // Vaadin login page
+                    AntPathRequestMatcher.antMatcher("/") // Allow access to root for Vaadin
+                ).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/api/v1/**")).authenticated()
+                .anyRequest().authenticated()
+            )
+            // If Vaadin's form login is to be preserved during transition:
+            .formLogin(form -> form
+                .loginPage("/login").permitAll()
+                .defaultSuccessUrl("/transactions", true) // Vaadin's default success redirect
+            )
+            .logout(logout -> logout
+                .logoutSuccessUrl("/login?logout")
+                .permitAll()
+            );
+
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,22 @@ spring.jpa.show-sql=false
 
 server.servlet.session.timeout=15m
 upload.dir=D:/Uploads
+
+# ===============================
+# JWT Configuration
+# ===============================
+# IMPORTANT: Change this secret in your production environment!
+# It should be a long, random string (at least 32 bytes for HS256).
+app.jwt.secret=ReplaceThisWithAStrongSecretKeyMinimum32BytesLongForHS256Security
+app.jwt.expiration-ms=86400000
+
+# ===============================
+# Springdoc OpenAPI Configuration
+# ===============================
+springdoc.api-docs.path=/api/v1/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.tryItOutEnabled=true
+# springdoc.show-actuator=false # Uncomment if you have actuator and want to hide it
+springdoc.writer.default-produces-media-type=application/json

--- a/src/test/java/com/cofeecode/application/powerhauscore/controllers/api/ProjectControllerTest.java
+++ b/src/test/java/com/cofeecode/application/powerhauscore/controllers/api/ProjectControllerTest.java
@@ -1,0 +1,108 @@
+package com.cofeecode.application.powerhauscore.controllers.api;
+
+import com.cofeecode.application.powerhauscore.data.Project;
+import com.cofeecode.application.powerhauscore.dto.ProjectRequestDTO;
+import com.cofeecode.application.powerhauscore.services.ProjectService;
+import com.cofeecode.application.powerhauscore.security.JwtAuthenticationFilter;
+import com.cofeecode.application.powerhauscore.security.JwtTokenProvider;
+import com.cofeecode.application.powerhauscore.security.UserDetailsServiceImpl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+// Remove csrf import if not used, or keep if you plan to enable CSRF selectively
+// import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@WebMvcTest(controllers = ProjectController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+            JwtAuthenticationFilter.class, JwtTokenProvider.class
+        })
+    }
+    // If UserDetailsServiceImpl is not found or causes issues, you might need to
+    // provide a @TestConfiguration with a mock bean for it, or ensure it's correctly picked up/excluded.
+    // For now, @MockBean for UserDetailsServiceImpl is added below.
+)
+public class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProjectService projectService;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsServiceImpl; // Mock UserDetailsService for WebMvcTest context
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Project project1;
+    private ProjectRequestDTO projectRequestDTO;
+
+    @BeforeEach
+    void setUp() {
+        project1 = new Project();
+        project1.setId(1L);
+        project1.setName("Test Project 1");
+        project1.setDescription("Description 1");
+        project1.setStartDate(LocalDate.now());
+        project1.setBudget(new BigDecimal("10000"));
+        project1.setStatus("ACTIVE");
+        project1.setClient("Client A");
+
+        projectRequestDTO = new ProjectRequestDTO(
+            "New Project", "New Desc", LocalDate.now().plusDays(1), null,
+            new BigDecimal("5000"), "PLANNED", "Client B", null, null, false
+        );
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER", "RVC", "HR", "ADMIN"})
+    void getAllProjects_shouldReturnPageOfProjects() throws Exception {
+        Page<Project> projectPage = new PageImpl<>(Collections.singletonList(project1), PageRequest.of(0, 10), 1);
+        when(projectService.list(any(Pageable.class))).thenReturn(projectPage);
+
+        mockMvc.perform(get("/api/v1/projects?page=0&size=10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value(project1.getName()))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER", "RVC", "HR", "ADMIN"})
+    void getProjectById_whenProjectExists_shouldReturnProject() throws Exception {
+        when(projectService.get(1L)).thenReturn(Optional.of(project1));
+
+        mockMvc.perform(get("/api/v1/projects/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(project1.getName()));
+    }
+
+    @Test
+    @WithMoc


### PR DESCRIPTION
This commit completes Phase 1 of the Vaadin to React migration strategy.

Key changes include:
- Added REST controllers (e.g., ProjectController) to expose business logic via APIs.
- Implemented stateless JWT-based authentication and authorization using Spring Security.
  - Includes JwtTokenProvider, JwtAuthenticationFilter, and updated SecurityConfiguration.
  - AuthController for login and token generation.
- Integrated Springdoc OpenAPI for API documentation (Swagger UI available at /swagger-ui.html).
- Established a pattern for API endpoint authorization using @RolesAllowed.
- Added example DTOs (ProjectRequestDTO, LoginRequestDTO, JwtResponseDTO).
- Included a sample unit test structure for API controllers (ProjectControllerTest).

The backend is now prepared to support a separate React frontend application.