### PR TITLE
fix: Correct syntax error in FileController Content-Disposition header

### DIFF
--- a/src/main/java/com/cofeecode/application/powerhauscore/controllers/FileController.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/controllers/FileController.java
@@ -74,7 +74,7 @@ public class FileController {
                 }
                 return ResponseEntity.ok()
                         .contentType(MediaType.parseMediaType(contentType))
-                        .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename="" + resource.getFilename() + """)
+                        .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\\"" + resource.getFilename() + "\\"")
                         .body(resource);
             } else {
                 return ResponseEntity.notFound().build();


### PR DESCRIPTION
The viewFile method had a syntax error in the construction of the Content-Disposition header string, specifically with improper quoting and escaping for the filename. This caused a compilation error.

The line has been corrected to properly escape the quotes around the filename value.