### PR TITLE
feat: Preserve all filters in TransactionListView

### DIFF
--- a/src/main/java/com/cofeecode/application/powerhauscore/views/transaction/TransactionEditView.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/views/transaction/TransactionEditView.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.ValidationException;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 
@@ -50,6 +51,7 @@ import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 //@PageTitle("Edit Transaction")
@@ -58,8 +60,17 @@ import java.util.Optional;
 public class TransactionEditView extends Div implements BeforeEnterObserver {
 
     private final String TRANSACTION_ID = "transactionID";
-    // Directory where uploaded files will be stored
-    private static final String UPLOAD_DIRECTORY = "D:/Java Projects/my-app/uploads";
+    private static final String UPLOAD_DIRECTORY = "D:/Java Projects/my-app/uploads"; // Directory where uploaded files will be stored
+
+    // Fields to store filter parameters
+    private String extraFilterValue;
+    private String categoryFilterValue;
+    private String descriptionFilterValue;
+    private String startDateValue;
+    private String endDateValue;
+    private String typeValue;
+    private String projectIdValue;
+    private String dagboekValue;
     private final TransactionService transactionService;
     private final ProjectService projectService;
     private final SettingsService settingsService;
@@ -101,6 +112,19 @@ public class TransactionEditView extends Div implements BeforeEnterObserver {
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
+        // Read filter parameters
+        QueryParameters queryParameters = event.getLocation().getQueryParameters();
+        Map<String, List<String>> parametersMap = queryParameters.getParameters();
+
+        extraFilterValue = parametersMap.getOrDefault("extraFilter", List.of()).stream().findFirst().orElse(null);
+        categoryFilterValue = parametersMap.getOrDefault("categoryFilter", List.of()).stream().findFirst().orElse(null);
+        descriptionFilterValue = parametersMap.getOrDefault("descriptionFilter", List.of()).stream().findFirst().orElse(null);
+        startDateValue = parametersMap.getOrDefault("startDate", List.of()).stream().findFirst().orElse(null);
+        endDateValue = parametersMap.getOrDefault("endDate", List.of()).stream().findFirst().orElse(null);
+        typeValue = parametersMap.getOrDefault("type", List.of()).stream().findFirst().orElse(null);
+        projectIdValue = parametersMap.getOrDefault("projectId", List.of()).stream().findFirst().orElse(null);
+        dagboekValue = parametersMap.getOrDefault("dagboek", List.of()).stream().findFirst().orElse(null);
+
         Optional<Long> transactionId = event.getRouteParameters().get(TRANSACTION_ID).map(Long::parseLong);
         if (transactionId.isPresent()) {
             Optional<Transaction> transactionFromBackend = transactionService.get(transactionId.get());
@@ -108,16 +132,17 @@ public class TransactionEditView extends Div implements BeforeEnterObserver {
                 transaction = transactionFromBackend.get();
             } else {
                 Notification.show("Transaction not found", 3000, Notification.Position.BOTTOM_START);
-                event.forwardTo(TransactionListView.class);
+                // Navigate back to list view, potentially with filters if they were passed
+                cancel();
                 return;
             }
-        }else {
-                transaction = new Transaction();
-            }
+        } else {
+            transaction = new Transaction();
+        }
         createForm();
         updatePageTitle();
         populateForm();
-        }
+    }
 
 
     private void createForm() {
@@ -587,9 +612,47 @@ public class TransactionEditView extends Div implements BeforeEnterObserver {
     }
 
 
-    private void cancel(){
-        UI.getCurrent().navigate(TransactionListView.class);
+    private void cancel() {
+        String route = "transactions";
+        List<String> queryParams = new ArrayList<>();
+
+        try {
+            if (extraFilterValue != null && !extraFilterValue.isEmpty()) {
+                queryParams.add("extraFilter=" + URLEncoder.encode(extraFilterValue, StandardCharsets.UTF_8.name()));
+            }
+            if (categoryFilterValue != null && !categoryFilterValue.isEmpty()) {
+                queryParams.add("categoryFilter=" + URLEncoder.encode(categoryFilterValue, StandardCharsets.UTF_8.name()));
+            }
+            if (descriptionFilterValue != null && !descriptionFilterValue.isEmpty()) {
+                queryParams.add("descriptionFilter=" + URLEncoder.encode(descriptionFilterValue, StandardCharsets.UTF_8.name()));
+            }
+            if (startDateValue != null && !startDateValue.isEmpty()) {
+                queryParams.add("startDate=" + URLEncoder.encode(startDateValue, StandardCharsets.UTF_8.name()));
+            }
+            if (endDateValue != null && !endDateValue.isEmpty()) {
+                queryParams.add("endDate=" + URLEncoder.encode(endDateValue, StandardCharsets.UTF_8.name()));
+            }
+            if (typeValue != null && !typeValue.isEmpty()) {
+                queryParams.add("type=" + URLEncoder.encode(typeValue, StandardCharsets.UTF_8.name()));
+            }
+            if (projectIdValue != null && !projectIdValue.isEmpty()) {
+                queryParams.add("projectId=" + URLEncoder.encode(projectIdValue, StandardCharsets.UTF_8.name()));
+            }
+            if (dagboekValue != null && !dagboekValue.isEmpty()) {
+                queryParams.add("dagboek=" + URLEncoder.encode(dagboekValue, StandardCharsets.UTF_8.name()));
+            }
+        } catch (Exception e) {
+            // Handle encoding exception if necessary, perhaps log it
+            Notification.show("Error encoding filter parameters", 3000, Notification.Position.BOTTOM_START)
+                    .addThemeVariants(NotificationVariant.LUMO_ERROR);
+        }
+
+        if (!queryParams.isEmpty()) {
+            route += "?" + String.join("&", queryParams);
+        }
+        UI.getCurrent().navigate(route);
     }
+
     private void deleteTransaction() {
         transactionService.delete(transaction.getId());
         UI.getCurrent().navigate(TransactionListView.class);

--- a/src/main/java/com/cofeecode/application/powerhauscore/views/transaction/TransactionListView.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/views/transaction/TransactionListView.java
@@ -39,11 +39,19 @@ import com.vaadin.flow.theme.lumo.LumoUtility;
 import jakarta.annotation.security.RolesAllowed;
 
 import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import com.vaadin.flow.router.QueryParameters;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
@@ -347,7 +355,49 @@ public class TransactionListView extends VerticalLayout implements BeforeEnterOb
 
         grid.asSingleSelect().addValueChangeListener(event -> {
             if (event.getValue() != null) {
-                UI.getCurrent().navigate(String.format(TRANSACTION_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+                String route = String.format(TRANSACTION_EDIT_ROUTE_TEMPLATE, event.getValue().getId());
+                List<String> queryParams = new ArrayList<>();
+
+                try {
+                    // Text filters
+                    if (extraFilter.getValue() != null && !extraFilter.getValue().isEmpty()) {
+                        queryParams.add("extraFilter=" + URLEncoder.encode(extraFilter.getValue(), StandardCharsets.UTF_8.name()));
+                    }
+                    if (categoryFilter.getValue() != null && !categoryFilter.getValue().isEmpty()) {
+                        queryParams.add("categoryFilter=" + URLEncoder.encode(categoryFilter.getValue(), StandardCharsets.UTF_8.name()));
+                    }
+                    if (descriptionFilter.getValue() != null && !descriptionFilter.getValue().isEmpty()) {
+                        queryParams.add("descriptionFilter=" + URLEncoder.encode(descriptionFilter.getValue(), StandardCharsets.UTF_8.name()));
+                    }
+
+                    // Date filters
+                    if (startDateFilter.getValue() != null) {
+                        queryParams.add("startDate=" + URLEncoder.encode(startDateFilter.getValue().toString(), StandardCharsets.UTF_8.name()));
+                    }
+                    if (endDateFilter.getValue() != null) {
+                        queryParams.add("endDate=" + URLEncoder.encode(endDateFilter.getValue().toString(), StandardCharsets.UTF_8.name()));
+                    }
+
+                    // ComboBox filters
+                    if (typeFilter.getValue() != null) {
+                        queryParams.add("type=" + URLEncoder.encode(typeFilter.getValue().name(), StandardCharsets.UTF_8.name()));
+                    }
+                    if (projectFilter.getValue() != null && projectFilter.getValue().getId() != null) {
+                        queryParams.add("projectId=" + URLEncoder.encode(String.valueOf(projectFilter.getValue().getId()), StandardCharsets.UTF_8.name()));
+                    }
+                    if (dagboekFilter.getValue() != null && !dagboekFilter.getValue().isEmpty()) {
+                        queryParams.add("dagboek=" + URLEncoder.encode(dagboekFilter.getValue(), StandardCharsets.UTF_8.name()));
+                    }
+
+                } catch (Exception e) {
+                    // Broad exception catch for URLEncoder.encode, consider more specific handling or logging
+                    System.err.println("Error encoding query parameters: " + e.getMessage());
+                }
+
+                if (!queryParams.isEmpty()) {
+                    route += "?" + String.join("&", queryParams);
+                }
+                UI.getCurrent().navigate(route);
             }
         });
 
@@ -463,5 +513,89 @@ public class TransactionListView extends VerticalLayout implements BeforeEnterOb
     }
 
     @Override
-    public void beforeEnter(BeforeEnterEvent event) {}
+    public void beforeEnter(BeforeEnterEvent event) {
+        QueryParameters queryParameters = event.getLocation().getQueryParameters();
+        Map<String, List<String>> parametersMap = queryParameters.getParameters();
+
+        boolean localFiltersAppliedFromUrl = false;
+
+        // Text filters
+        String extraFilterParam = parametersMap.getOrDefault("extraFilter", List.of()).stream().findFirst().orElse(null);
+        if (extraFilterParam != null) {
+            extraFilter.setValue(extraFilterParam);
+            localFiltersAppliedFromUrl = true;
+        }
+
+        String categoryFilterParam = parametersMap.getOrDefault("categoryFilter", List.of()).stream().findFirst().orElse(null);
+        if (categoryFilterParam != null) {
+            categoryFilter.setValue(categoryFilterParam);
+            localFiltersAppliedFromUrl = true;
+        }
+
+        String descriptionFilterParam = parametersMap.getOrDefault("descriptionFilter", List.of()).stream().findFirst().orElse(null);
+        if (descriptionFilterParam != null) {
+            descriptionFilter.setValue(descriptionFilterParam);
+            localFiltersAppliedFromUrl = true;
+        }
+
+        // Date filters
+        String startDateParam = parametersMap.getOrDefault("startDate", List.of()).stream().findFirst().orElse(null);
+        if (startDateParam != null) {
+            try {
+                startDateFilter.setValue(LocalDate.parse(startDateParam));
+                localFiltersAppliedFromUrl = true;
+            } catch (DateTimeParseException e) {
+                System.err.println("Error parsing startDate: " + startDateParam + " - " + e.getMessage());
+            }
+        }
+
+        String endDateParam = parametersMap.getOrDefault("endDate", List.of()).stream().findFirst().orElse(null);
+        if (endDateParam != null) {
+            try {
+                endDateFilter.setValue(LocalDate.parse(endDateParam));
+                localFiltersAppliedFromUrl = true;
+            } catch (DateTimeParseException e) {
+                System.err.println("Error parsing endDate: " + endDateParam + " - " + e.getMessage());
+            }
+        }
+
+        // ComboBox filters
+        String typeParam = parametersMap.getOrDefault("type", List.of()).stream().findFirst().orElse(null);
+        if (typeParam != null) {
+            try {
+                typeFilter.setValue(TransactionType.valueOf(typeParam));
+                localFiltersAppliedFromUrl = true;
+            } catch (IllegalArgumentException e) {
+                System.err.println("Error parsing type: " + typeParam + " - " + e.getMessage());
+            }
+        }
+
+        String projectIdParam = parametersMap.getOrDefault("projectId", List.of()).stream().findFirst().orElse(null);
+        if (projectIdParam != null) {
+            try {
+                Long pId = Long.parseLong(projectIdParam);
+                Optional<Project> projectToSelect = projectFilter.getDataProvider().fetch(new com.vaadin.flow.data.provider.Query<>())
+                        .filter(p -> p.getId().equals(pId))
+                        .findFirst();
+                if (projectToSelect.isPresent()) {
+                    projectFilter.setValue(projectToSelect.get());
+                    localFiltersAppliedFromUrl = true;
+                } else {
+                     System.err.println("Project with ID: " + projectIdParam + " not found in projectFilter items.");
+                }
+            } catch (NumberFormatException e) {
+                System.err.println("Error parsing projectId: " + projectIdParam + " - " + e.getMessage());
+            }
+        }
+
+        String dagboekParam = parametersMap.getOrDefault("dagboek", List.of()).stream().findFirst().orElse(null);
+        if (dagboekParam != null) {
+            dagboekFilter.setValue(dagboekParam);
+            localFiltersAppliedFromUrl = true;
+        }
+
+        if (localFiltersAppliedFromUrl) {
+            updateFilteredGrid();
+        }
+    }
 }


### PR DESCRIPTION
This change ensures that all filter settings in TransactionListView are preserved when you navigate to TransactionEditView and then return by clicking the 'Cancel' button.

Modifications include:
- Passing filter values (TextFilters, DatePickers, ComboBoxes) as URL query parameters from TransactionListView to TransactionEditView.
- Storing these parameters in TransactionEditView and appending them to the navigation URI when returning to TransactionListView.
- Reading the query parameters in TransactionListView's beforeEnter method, converting them to their appropriate types, and reapplying them to the filter components and the grid.
- Handled data types: String, LocalDate, Enum (TransactionType), and Entity ID (Project).
- Fixed an issue where a helper class NonFinalStateHolder was incorrectly referenced; replaced with a local boolean flag.