### PR TITLE
Add lead management views

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Once the JAR file is built, you can run it using
 
 ## Project structure
 
+The project structure includes multiple example views. The new lead management feature lives under `src/main/java/com/cofeecode/application/powerhauscore/views/lead`. Use `/leads` in your browser to manage incoming business leads and convert them to active projects. Existing project views remain under `views/project` for comparison.
+
 - `MainLayout.java` in `src/main/java` contains the navigation setup (i.e., the
   side/top bar and the main menu). This setup uses
   [App Layout](https://vaadin.com/docs/components/app-layout).

--- a/src/main/java/com/cofeecode/application/powerhauscore/repository/ProjectRepository.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/repository/ProjectRepository.java
@@ -1,11 +1,13 @@
 package com.cofeecode.application.powerhauscore.repository;
 
 import com.cofeecode.application.powerhauscore.data.Project;
+import com.cofeecode.application.powerhauscore.data.ProjectStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, JpaSpecificationExecutor<Project> {
 
-
+List<Project> findByStatus(ProjectStatus status);
 
 }

--- a/src/main/java/com/cofeecode/application/powerhauscore/services/ProjectService.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/services/ProjectService.java
@@ -1,6 +1,7 @@
 package com.cofeecode.application.powerhauscore.services;
 
 import com.cofeecode.application.powerhauscore.data.Project;
+import com.cofeecode.application.powerhauscore.data.ProjectStatus;
 import com.cofeecode.application.powerhauscore.repository.ProjectRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,5 +46,18 @@ public class ProjectService {
 
     public List<Project> findAll() {
         return repository.findAll();
+    }
+
+    public List<Project> findByStatus(ProjectStatus status) {
+        return repository.findByStatus(status);
+    }
+
+    public Optional<Project> updateStatus(Long id, ProjectStatus status) {
+        Optional<Project> projectOpt = repository.findById(id);
+        projectOpt.ifPresent(p -> {
+            p.setStatus(status);
+            repository.save(p);
+        });
+        return projectOpt;
     }
 }

--- a/src/main/java/com/cofeecode/application/powerhauscore/views/lead/LeadEditView.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/views/lead/LeadEditView.java
@@ -1,0 +1,19 @@
+package com.cofeecode.application.powerhauscore.views.lead;
+
+import com.cofeecode.application.powerhauscore.services.ProjectService;
+import com.cofeecode.application.powerhauscore.security.AuthenticatedUser;
+import com.cofeecode.application.powerhauscore.views.MainLayout;
+import com.cofeecode.application.powerhauscore.views.project.ProjectEditView;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.RolesAllowed;
+
+@PageTitle("Edit Lead")
+@Route(value = "leads/:projectID?/edit", layout = MainLayout.class)
+@RolesAllowed({"USER", "ADMIN", "HR"})
+public class LeadEditView extends ProjectEditView {
+
+    public LeadEditView(ProjectService projectService, AuthenticatedUser authenticatedUser) {
+        super(projectService, authenticatedUser);
+    }
+}

--- a/src/main/java/com/cofeecode/application/powerhauscore/views/lead/LeadListView.java
+++ b/src/main/java/com/cofeecode/application/powerhauscore/views/lead/LeadListView.java
@@ -1,0 +1,75 @@
+package com.cofeecode.application.powerhauscore.views.lead;
+
+import com.cofeecode.application.powerhauscore.data.Project;
+import com.cofeecode.application.powerhauscore.data.ProjectStatus;
+import com.cofeecode.application.powerhauscore.services.ProjectService;
+import com.cofeecode.application.powerhauscore.views.MainLayout;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.RolesAllowed;
+
+import java.util.List;
+
+@PageTitle("Leads")
+@Route(value = "leads", layout = MainLayout.class)
+@RolesAllowed({"USER", "ADMIN", "HR"})
+public class LeadListView extends VerticalLayout {
+
+    private final ProjectService projectService;
+    private final Grid<Project> grid = new Grid<>(Project.class, false);
+
+    public LeadListView(ProjectService projectService) {
+        this.projectService = projectService;
+        addClassName("lead-list-view");
+        setSizeFull();
+
+        configureGrid();
+        add(createToolbar(), grid);
+        updateList();
+    }
+
+    private HorizontalLayout createToolbar() {
+        Button newLeadButton = new Button("New Lead", click -> UI.getCurrent().navigate(LeadEditView.class));
+        newLeadButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        HorizontalLayout toolbar = new HorizontalLayout(newLeadButton);
+        toolbar.addClassName("toolbar");
+        return toolbar;
+    }
+
+    private void configureGrid() {
+        grid.addClassName("lead-grid");
+        grid.setSizeFull();
+        grid.addColumn(Project::getName).setHeader("Name").setSortable(true);
+        grid.addColumn(Project::getClient).setHeader("Client").setSortable(true);
+        grid.addColumn(Project::getManager).setHeader("Owner").setSortable(true);
+
+        grid.addComponentColumn(project -> {
+            Button convert = new Button("Convert", e -> convertLead(project));
+            convert.addThemeVariants(ButtonVariant.LUMO_SUCCESS);
+            return convert;
+        }).setHeader("Actions");
+
+        grid.asSingleSelect().addValueChangeListener(event -> {
+            if (event.getValue() != null) {
+                UI.getCurrent().navigate(LeadEditView.class + "/" + event.getValue().getId());
+            }
+        });
+    }
+
+    private void updateList() {
+        List<Project> leads = projectService.findByStatus(ProjectStatus.LEAD);
+        grid.setItems(leads);
+    }
+
+    private void convertLead(Project lead) {
+        projectService.updateStatus(lead.getId(), ProjectStatus.APPROVED);
+        UI.getCurrent().navigate("projects/" + lead.getId() + "/edit");
+    }
+}


### PR DESCRIPTION
## Summary
- enable look-up by status in `ProjectRepository`
- add helper methods for status changes in `ProjectService`
- create `LeadListView` and `LeadEditView` for tracking new business leads
- document new lead flow in README

## Testing
- `./mvnw -q -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687f09d3d04083258c444b27731039d7